### PR TITLE
Allow ips advertised as internal services

### DIFF
--- a/storage-node.tf
+++ b/storage-node.tf
@@ -109,6 +109,8 @@ data "ignition_file" "storage_node_iptables_rules" {
 -A INPUT -p tcp -m tcp -s "${var.ssh_address_range}" --dport 22 -m conntrack --ctstate NEW,ESTABLISHED -j ACCEPT
 # Allow pod subnet input https://github.com/kubernetes/kubeadm/issues/1461#issuecomment-489362994
 -A INPUT -s "${var.pod_network}" -j ACCEPT
+# Allow packets destined to internal services ip range
+-A INPUT -d "${var.cluster_internal_svc_subnet}" -j ACCEPT
 # Allow masters to talk to workers
 -A INPUT -p tcp -m tcp -s "${var.masters_subnet_cidr}" -j ACCEPT
 -A INPUT -p udp -m udp -s "${var.masters_subnet_cidr}" -j ACCEPT

--- a/variables.tf
+++ b/variables.tf
@@ -123,6 +123,10 @@ variable "cluster_subnet" {
   description = "Cluster ip subnet"
 }
 
+variable "cluster_internal_svc_subnet" {
+  description = "Advertised ip subnet for internal services"
+}
+
 variable "pod_network" {
   description = "pod network cidr"
 }

--- a/worker.tf
+++ b/worker.tf
@@ -65,6 +65,8 @@ data "ignition_file" "worker_iptables_rules" {
 -A INPUT -p tcp -m tcp -s "${var.ssh_address_range}" --dport 22 -m conntrack --ctstate NEW,ESTABLISHED -j ACCEPT
 # Allow pod subnet input https://github.com/kubernetes/kubeadm/issues/1461#issuecomment-489362994
 -A INPUT -s "${var.pod_network}" -j ACCEPT
+# Allow packets destined to internal services ip range
+-A INPUT -d "${var.cluster_internal_svc_subnet}" -j ACCEPT
 # Allow masters to talk to workers
 -A INPUT -p tcp -m tcp -s "${var.masters_subnet_cidr}" -j ACCEPT
 -A INPUT -p udp -m udp -s "${var.masters_subnet_cidr}" -j ACCEPT


### PR DESCRIPTION
If ipvs mode is used with kube-proxy, it means that packets arriving for virtual
internal service ips will need an iptables rule to be accepted in before we can
route via ipvs