### PR TITLE
Use netdev bonding for etcds

### DIFF
--- a/common.tf
+++ b/common.tf
@@ -46,3 +46,28 @@ EOS
 
 }
 
+# Common Network config
+# Bond network interfaces eno*
+data "ignition_networkd_unit" "bond_net_eno" {
+  name    = "00-eno.network"
+  content = <<EOS
+[Match]
+Name=eno*
+
+[Network]
+Bond=bond0
+EOS
+}
+
+# bond0 device
+data "ignition_networkd_unit" "bond_netdev" {
+  name    = "10-bond0.netdev"
+  content = <<EOS
+[NetDev]
+Name=bond0
+Kind=bond
+
+[Bond]
+Mode=802.3ad
+EOS
+}

--- a/groups.tf
+++ b/groups.tf
@@ -11,20 +11,6 @@ resource "matchbox_group" "cfssl" {
   }
 }
 
-resource "matchbox_group" "etcd" {
-  count   = var.etcd_instance_count
-  name    = "etcd-${count.index}"
-  profile = matchbox_profile.etcd[count.index].name
-
-  selector = {
-    mac = var.etcd_mac_addresses[count.index]
-  }
-
-  metadata = {
-    ignition_endpoint = "${var.matchbox_http_endpoint}/ignition"
-  }
-}
-
 resource "matchbox_group" "master" {
   count   = var.masters_instance_count
   name    = "master-${count.index}"

--- a/output.tf
+++ b/output.tf
@@ -2,10 +2,6 @@ output "cfssl_dns_name" {
   value = local.cfssl_dns_name
 }
 
-output "etcd_dns_names" {
-  value = null_resource.etcd_hostnames.*.triggers.name
-}
-
 output "master_dns_names" {
   value = null_resource.masters.*.triggers.name
 }
@@ -23,7 +19,7 @@ output "cfssl_data_volumeid" {
 }
 
 output "etcd_data_volumeids" {
-  value = null_resource.etcd_partlabels.*.triggers.label
+  value = [for e in var.etcd_members: "disk/by-partlabel/${var.etcd-partlabel}"]
 }
 
 output "storage_node_volumeid" {

--- a/variables.tf
+++ b/variables.tf
@@ -34,18 +34,16 @@ variable "ssh_address_range" {
   description = "Address range from which to allow ssh"
 }
 
-variable "etcd_instance_count" {
-  default     = 3
-  description = "etcd members count"
-}
+variable "etcd_members" {
+  description = "List of mac addresses for each etcd member"
 
-variable "etcd_mac_addresses" {
-  type        = list(string)
-  description = "Mac address of etcd member nodes"
+  type = list(object({
+    mac_addresses = list(string)
+  }))
 }
 
 variable "etcd_subnet_cidr" {
-  description = "Address range for etcd members"
+  description = "Address range for etcd members for iptables rules"
 }
 
 variable "etcd_ignition_systemd" {


### PR DESCRIPTION
- Will allow us to use portchannels and ha network
- removes etcd related null resources
- removes static hostnames (to be served via dhcp)