### PR TITLE
Add static hostnames in generated profiles

### DIFF
--- a/cfssl.tf
+++ b/cfssl.tf
@@ -32,6 +32,19 @@ resource "matchbox_group" "cfssl" {
   }
 }
 
+# Set a hostname
+data "ignition_file" "cfssl_hostname" {
+  filesystem = "root"
+  path       = "/etc/hostname"
+  mode       = 420
+
+  content {
+    content = <<EOS
+cfssl.${var.dns_domain}
+EOS
+  }
+}
+
 # Create the bond interface for each node
 # use first available mac address to override
 data "ignition_networkd_unit" "bond0_cfssl" {
@@ -114,6 +127,7 @@ data "ignition_config" "cfssl" {
 
   files = concat(
     [
+      data.ignition_file.cfssl_hostname.id,
       data.ignition_file.cfssl_iptables_rules.id,
     ],
     var.cfssl_ignition_files,


### PR DESCRIPTION
We saw an issue where kubelet was starting before a hostname could be set via
dhcp offering, which resulted in nodes registering to the cluster as
`localhost`. Since we use explicit matchbox profiles per instance we can remedy
that via static hostnames so that nodes do not init as localhost anymore.