### PR TITLE
Configure workers to use jumboframes (9000mtu)

### DIFF
--- a/worker.tf
+++ b/worker.tf
@@ -64,6 +64,20 @@ EOS
   }
 }
 
+data "ignition_networkd_unit" "bond_net_eno_worker" {
+  name    = "00-eno.network"
+  content = <<EOS
+[Match]
+Name=eno*
+
+[Link]
+MTUBytes=9000
+
+[Network]
+Bond=bond0
+EOS
+}
+
 # Create the bond interface for each node
 # use first available mac address to override
 data "ignition_networkd_unit" "bond0_worker" {
@@ -75,6 +89,7 @@ data "ignition_networkd_unit" "bond0_worker" {
 Name=bond0
 
 [Link]
+MTUBytes=9000
 MACAddress=${var.worker_instances[count.index].mac_addresses[0]}
 
 [Network]
@@ -90,7 +105,7 @@ data "ignition_config" "worker" {
   ]
 
   networkd = [
-    data.ignition_networkd_unit.bond_net_eno.id,
+    data.ignition_networkd_unit.bond_net_eno_worker.id,
     data.ignition_networkd_unit.bond_netdev.id,
     data.ignition_networkd_unit.bond0_worker[count.index].id,
   ]


### PR DESCRIPTION
```
2: eno1: <BROADCAST,MULTICAST,SLAVE,UP,LOWER_UP> mtu 9000 qdisc mq master bond0 state UP group default qlen 1000                                                                                            
    link/ether ec:eb:b8:a5:75:c2 brd ff:ff:ff:ff:ff:ff                                                                                                                                                      
3: eno1d1: <BROADCAST,MULTICAST,SLAVE,UP,LOWER_UP> mtu 9000 qdisc mq master bond0 state UP group default qlen 1000                                                                                          
    link/ether ec:eb:b8:a5:75:c2 brd ff:ff:ff:ff:ff:ff                                                                                                                                                      
4: bond0: <BROADCAST,MULTICAST,MASTER,UP,LOWER_UP> mtu 9000 qdisc noqueue state UP group default qlen 1000                                                                                                  
    link/ether ec:eb:b8:a5:75:c2 brd ff:ff:ff:ff:ff:ff                                                                                                                                                      
    inet 10.88.0.128/24 brd 10.88.0.255 scope global dynamic bond0                                                                                                                                          
       valid_lft 42968sec preferred_lft 42968sec                                                                                                                                                            
    inet6 fe80::eeeb:b8ff:fea5:75c2/64 scope link                                                                                                                                                           
       valid_lft forever preferred_lft forever
```