### PR TITLE
Eliminate unknowns at runtime

### DIFF
--- a/etcd.tf
+++ b/etcd.tf
@@ -26,10 +26,10 @@ resource "matchbox_profile" "etcd" {
 # }
 locals {
   etcd_groups = flatten([
-    for index, profile in matchbox_profile.etcd : [
+    for index, _ in var.etcd_members : [
       for _, mac_address in var.etcd_members[index].mac_addresses : {
         mac     = mac_address
-        profile = profile
+        profile = matchbox_profile.etcd[index]
       }
     ]
   ])

--- a/master.tf
+++ b/master.tf
@@ -26,10 +26,10 @@ resource "matchbox_profile" "master" {
 # }
 locals {
   master_groups = flatten([
-    for index, profile in matchbox_profile.master : [
+    for index, _ in var.master_instances : [
       for _, mac_address in var.master_instances[index].mac_addresses : {
         mac     = mac_address
-        profile = profile
+        profile = matchbox_profile.master[index]
       }
     ]
   ])

--- a/worker.tf
+++ b/worker.tf
@@ -26,10 +26,10 @@ resource "matchbox_profile" "worker" {
 # }
 locals {
   worker_groups = flatten([
-    for index, profile in matchbox_profile.worker : [
+    for index, _ in var.worker_instances : [
       for _, mac_address in var.worker_instances[index].mac_addresses : {
         mac     = mac_address
-        profile = profile
+        profile = matchbox_profile.worker[index]
       }
     ]
   ])


### PR DESCRIPTION
By iterating over a variable instead of over a resource, the module can
be applied in one go, instead of having to apply matchbox_profiles on
step 1, and matchbox_groups in step 2

This also allows to remove instances by removing them from the variable
list, instead of needing to remove them manually from the state