### PR TITLE
Specify disk type for etcd and master instances

### DIFF
--- a/etcd.tf
+++ b/etcd.tf
@@ -50,8 +50,24 @@ variable "etcd-partlabel" {
   default = "ETCD"
 }
 
-data "ignition_disk" "etcd-sda" {
+data "ignition_disk" "etcd_sda" {
   device     = "/dev/sda"
+  wipe_table = true
+
+  partition {
+    size   = 50011340 // Approx 25 gigs
+    label  = var.etcd-partlabel
+    number = 1
+  }
+
+  partition {
+    label  = "ROOT"
+    number = 2
+  }
+}
+
+data "ignition_disk" "etcd_nvme" {
+  device     = "/dev/nvme0n1"
   wipe_table = true
 
   partition {
@@ -166,7 +182,7 @@ data "ignition_config" "etcd" {
   count = length(var.etcd_members)
 
   disks = [
-    data.ignition_disk.etcd-sda.rendered,
+    var.etcd_members[count.index].disk_type == "nvme" ? data.ignition_disk.etcd_nvme.rendered : data.ignition_disk.etcd_sda.rendered,
   ]
 
   networkd = [

--- a/master.tf
+++ b/master.tf
@@ -83,7 +83,7 @@ data "ignition_config" "master" {
   count = length(var.master_instances)
 
   disks = [
-    data.ignition_disk.devsda.rendered,
+    var.master_instances[count.index].disk_type == "nvme" ? data.ignition_disk.devnvme.rendered : data.ignition_disk.devsda.rendered,
   ]
 
   networkd = [

--- a/variables.tf
+++ b/variables.tf
@@ -48,11 +48,20 @@ variable "ssh_address_range" {
 }
 
 variable "etcd_members" {
-  description = "List of mac addresses for each etcd member"
+  description = "List of mac addresses and disk type for each etcd member"
 
   type = list(object({
     mac_addresses = list(string)
+    disk_type     = string
   }))
+
+  validation {
+    condition = alltrue([
+      for e in var.etcd_members : contains(["sata", "nvme"], e.disk_type)
+    ])
+    error_message = "All etcd members must specify a disk type of either sata or nvme."
+  }
+
 }
 
 variable "etcd_subnet_cidr" {
@@ -75,11 +84,20 @@ variable "etcd_ignition_directories" {
 }
 
 variable "master_instances" {
-  description = "List of mac addresses for each master node"
+  description = "List of mac addresses and disk type for each master node"
 
   type = list(object({
     mac_addresses = list(string)
+    disk_type     = string
   }))
+
+  validation {
+    condition = alltrue([
+      for m in var.master_instances : contains(["sata", "nvme"], m.disk_type)
+    ])
+    error_message = "All master instances must specify a disk type of either sata or nvme."
+  }
+
 }
 
 variable "masters_subnet_cidr" {


### PR DESCRIPTION
As we move out of a single moonshot to support running everything on different
metal we should be more flexible regarding our root volumes. For example on
m510 nodes we use sata drives, while on m710x we are on nvme