### PR TITLE
Update terraform-provider-ignition

### DIFF
--- a/common.tf
+++ b/common.tf
@@ -21,14 +21,10 @@ data "ignition_disk" "devsda" {
 }
 
 data "ignition_filesystem" "root" {
-  name = "ROOT"
-
-  mount {
-    device          = "/dev/disk/by-partlabel/ROOT"
-    format          = "ext4"
-    wipe_filesystem = true
-    label           = "ROOT"
-  }
+  device          = "/dev/disk/by-partlabel/ROOT"
+  format          = "ext4"
+  wipe_filesystem = true
+  label           = "ROOT"
 }
 
 data "ignition_systemd_unit" "iptables-rule-load" {
@@ -48,9 +44,12 @@ EOS
 
 # Common Network config
 # Bond network interfaces eno*
-data "ignition_networkd_unit" "bond_net_eno" {
-  name    = "00-eno.network"
-  content = <<EOS
+data "ignition_file" "bond_net_eno" {
+  path = "/etc/systemd/network/00-eno.network"
+  mode = 420
+
+  content {
+    content = <<EOS
 [Match]
 Name=eno*
 
@@ -60,12 +59,16 @@ MTUBytes=9000
 [Network]
 Bond=bond0
 EOS
+  }
 }
 
 # bond0 device
-data "ignition_networkd_unit" "bond_netdev" {
-  name    = "10-bond0.netdev"
-  content = <<EOS
+data "ignition_file" "bond_netdev" {
+  path = "/etc/systemd/network/10-bond0.netdev"
+  mode = 420
+
+  content {
+    content = <<EOS
 [NetDev]
 Name=bond0
 Kind=bond
@@ -73,4 +76,5 @@ Kind=bond
 [Bond]
 Mode=802.3ad
 EOS
+  }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -3,7 +3,6 @@ terraform {
   required_providers {
     ignition = {
       source  = "community-terraform-providers/ignition"
-      version = "< 2.0.0"
     }
     matchbox = {
       source = "poseidon/matchbox"

--- a/worker.tf
+++ b/worker.tf
@@ -48,10 +48,9 @@ resource "matchbox_group" "worker" {
 
 # Set a hostname
 data "ignition_file" "worker_hostname" {
-  count      = length(var.worker_instances)
-  filesystem = "root"
-  path       = "/etc/hostname"
-  mode       = 420
+  count = length(var.worker_instances)
+  path  = "/etc/hostname"
+  mode  = 420
 
   content {
     content = <<EOS
@@ -62,11 +61,14 @@ EOS
 
 # Create the bond interface for each node
 # use first available mac address to override
-data "ignition_networkd_unit" "bond0_worker" {
+data "ignition_file" "bond0_worker" {
   count = length(var.worker_instances)
 
-  name    = "20-bond0.network"
-  content = <<EOS
+  path = "/etc/systemd/network/20-bond0.network"
+  mode = 420
+
+  content {
+    content = <<EOS
 [Match]
 Name=bond0
 
@@ -77,6 +79,7 @@ MACAddress=${var.worker_instances[count.index].mac_addresses[0]}
 [Network]
 DHCP=yes
 EOS
+  }
 }
 
 data "ignition_config" "worker" {
@@ -84,12 +87,6 @@ data "ignition_config" "worker" {
 
   disks = [
     var.worker_instances[count.index].disk_type == "nvme" ? data.ignition_disk.devnvme.rendered : data.ignition_disk.devsda.rendered,
-  ]
-
-  networkd = [
-    data.ignition_networkd_unit.bond_net_eno.rendered,
-    data.ignition_networkd_unit.bond_netdev.rendered,
-    data.ignition_networkd_unit.bond0_worker[count.index].rendered,
   ]
 
   filesystems = [
@@ -103,6 +100,9 @@ data "ignition_config" "worker" {
   files = concat(
     var.worker_ignition_files,
     [
+      data.ignition_file.bond_net_eno.rendered,
+      data.ignition_file.bond_netdev.rendered,
+      data.ignition_file.bond0_worker[count.index].rendered,
       data.ignition_file.worker_hostname[count.index].rendered,
     ]
   )


### PR DESCRIPTION
- Do not pin ignition terraform provider to < 2.0.0
- Support format for latest ignition. Some fields do not match docs:
https://github.com/community-terraform-providers/terraform-provider-ignition/issues/17
- networkd units are now replaced by single files (what effectively are).