### PR TITLE
Optional local disk partition for cfssl data

### DIFF
--- a/cfssl.tf
+++ b/cfssl.tf
@@ -112,7 +112,7 @@ data "ignition_disk" "cfssl-local-partition" {
   wipe_table = true
 
   partition {
-    sizemib = 12502835 // Approx 5 gigs
+    sizemib = 5000 // Approx 5 gigs
     label   = var.cfssl-partlabel
     number  = 1
   }

--- a/cfssl.tf
+++ b/cfssl.tf
@@ -103,14 +103,46 @@ EOS
   }
 }
 
+variable "cfssl-partlabel" {
+  default = "CFSSL"
+}
+
+data "ignition_disk" "cfssl-local-partition" {
+  device     = var.cfssl_instance.disk_type == "nvme" ? "/dev/nvme0n1" : "/dev/sda"
+  wipe_table = true
+
+  partition {
+    sizemib = 12502835 // Approx 5 gigs
+    label   = var.cfssl-partlabel
+    number  = 1
+  }
+
+  partition {
+    label  = "ROOT"
+    number = 2
+  }
+}
+
+data "ignition_filesystem" "cfssl" {
+  device = "/dev/disk/by-partlabel/${var.cfssl-partlabel}"
+  format = "ext4"
+}
+
+locals {
+  no_local_partition = var.cfssl_instance.disk_type == "nvme" ? data.ignition_disk.devnvme.rendered : data.ignition_disk.devsda.rendered
+  local_partition    = data.ignition_disk.cfssl-local-partition.rendered
+  disk               = var.cfssl_local_patition_disk ? local.local_partition : local.no_local_partition
+}
+
 // Get ignition config from the module
 data "ignition_config" "cfssl" {
   disks = [
-    var.cfssl_instance.disk_type == "nvme" ? data.ignition_disk.devnvme.rendered : data.ignition_disk.devsda.rendered,
+    local.disk,
   ]
 
   filesystems = [
     data.ignition_filesystem.root.rendered,
+    var.cfssl_local_patition_disk ? data.ignition_filesystem.cfssl.rendered : "",
   ]
 
   systemd = concat(

--- a/output.tf
+++ b/output.tf
@@ -1,3 +1,7 @@
+output "cfssl_local_data_volumeid" {
+  value = "disk/by-partlabel/${var.cfssl-partlabel}"
+}
+
 output "etcd_data_volumeids" {
-  value = [for e in var.etcd_members: "disk/by-partlabel/${var.etcd-partlabel}"]
+  value = [for e in var.etcd_members : "disk/by-partlabel/${var.etcd-partlabel}"]
 }

--- a/variables.tf
+++ b/variables.tf
@@ -171,3 +171,9 @@ variable "cluster_internal_svc_subnet" {
 variable "pod_network" {
   description = "pod network cidr"
 }
+
+variable "cfssl_local_patition_disk" {
+  description = "Whether to create a local disk partition for storing cfssl data"
+  type        = bool
+  default     = false
+}


### PR DESCRIPTION
Adds a flag to allow partitioning space in the root disk that will not be wiped during boot to store cfssl data. Defaults to false, which will be noop for existing deployments.
To be used for env migration where we won't have access to iscsi servers.