### PR TITLE
Exp 1 ld7 move

### DIFF
--- a/cfssl.tf
+++ b/cfssl.tf
@@ -112,7 +112,7 @@ data "ignition_disk" "cfssl-local-partition" {
   wipe_table = true
 
   partition {
-    sizemib = 12502835 // Approx 5 gigs
+    sizemib = 5000 // Approx 5 gigs
     label   = var.cfssl-partlabel
     number  = 1
   }

--- a/cfssl.tf
+++ b/cfssl.tf
@@ -103,14 +103,46 @@ EOS
   }
 }
 
+variable "cfssl-partlabel" {
+  default = "CFSSL"
+}
+
+data "ignition_disk" "cfssl-local-partition" {
+  device     = var.cfssl_instance.disk_type == "nvme" ? "/dev/nvme0n1" : "/dev/sda"
+  wipe_table = true
+
+  partition {
+    sizemib = 12502835 // Approx 5 gigs
+    label   = var.cfssl-partlabel
+    number  = 1
+  }
+
+  partition {
+    label  = "ROOT"
+    number = 2
+  }
+}
+
+data "ignition_filesystem" "cfssl" {
+  device = "/dev/disk/by-partlabel/${var.cfssl-partlabel}"
+  format = "ext4"
+}
+
+locals {
+  no_local_partition = var.cfssl_instance.disk_type == "nvme" ? data.ignition_disk.devnvme.rendered : data.ignition_disk.devsda.rendered
+  local_partition    = data.ignition_disk.cfssl-local-partition.rendered
+  disk               = var.cfssl_local_patition_disk ? local.local_partition : local.no_local_partition
+}
+
 // Get ignition config from the module
 data "ignition_config" "cfssl" {
   disks = [
-    var.cfssl_instance.disk_type == "nvme" ? data.ignition_disk.devnvme.rendered : data.ignition_disk.devsda.rendered,
+    local.disk,
   ]
 
   filesystems = [
     data.ignition_filesystem.root.rendered,
+    var.cfssl_local_patition_disk ? data.ignition_filesystem.cfssl.rendered : "",
   ]
 
   systemd = concat(

--- a/cfssl.tf
+++ b/cfssl.tf
@@ -129,15 +129,15 @@ data "ignition_filesystem" "cfssl" {
 }
 
 locals {
-  no_local_partition = var.cfssl_instance.disk_type == "nvme" ? data.ignition_disk.devnvme.rendered : data.ignition_disk.devsda.rendered
-  local_partition    = data.ignition_disk.cfssl-local-partition.rendered
-  disk               = var.cfssl_local_patition_disk ? local.local_partition : local.no_local_partition
+  cfssl_no_local_partition = var.cfssl_instance.disk_type == "nvme" ? data.ignition_disk.devnvme.rendered : data.ignition_disk.devsda.rendered
+  cfssl_local_partition    = data.ignition_disk.cfssl-local-partition.rendered
+  cfssl_disk               = var.cfssl_local_patition_disk ? local.cfssl_local_partition : local.cfssl_no_local_partition
 }
 
 // Get ignition config from the module
 data "ignition_config" "cfssl" {
   disks = [
-    local.disk,
+    local.cfssl_disk,
   ]
 
   filesystems = [

--- a/output.tf
+++ b/output.tf
@@ -1,3 +1,7 @@
+output "cfssl_local_data_volumeid" {
+  value = "disk/by-partlabel/${var.cfssl-partlabel}"
+}
+
 output "etcd_data_volumeids" {
-  value = [for e in var.etcd_members: "disk/by-partlabel/${var.etcd-partlabel}"]
+  value = [for e in var.etcd_members : "disk/by-partlabel/${var.etcd-partlabel}"]
 }

--- a/resources/disk-mounter.service
+++ b/resources/disk-mounter.service
@@ -1,0 +1,8 @@
+[Unit]
+Description=Mounts device on mountpoint, formatting it if necessary
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=${script_path} ${volume_id} ${filesystem} ${user} ${group} ${mountpoint}
+[Install]
+WantedBy=multi-user.target

--- a/resources/format-and-mount
+++ b/resources/format-and-mount
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+readonly volume_id="$1"
+readonly filesystem="$2"
+readonly user="$3"
+readonly group="$4"
+readonly mountpoint="$5"
+
+# Location used by providers:
+# AWS nvme (m5): /dev/disk/by-id/nvme-Amazon_Elastic_Block_Store_${volume_id}
+# AWS non-nvme (t2): /dev/${volume_id}
+# GCP: /dev/disk/by-id/google-${volume_id}
+readonly locations="
+  /dev/disk/by-id/nvme-Amazon_Elastic_Block_Store_${volume_id}
+  /dev/${volume_id}
+  /dev/disk/by-id/google-${volume_id}
+"
+until mountpoint -q ${mountpoint}; do
+  sleep 8
+  for device in ${locations}; do
+    echo "Looking for device ${device}..."
+    if [[ -e "${device}" ]]; then
+      echo "Device ${device} found"
+      fsck -a ${device} || (
+        mkfs.${filesystem} ${device} \
+        && mount ${device} /mnt \
+        && chown -R ${user}:${group} /mnt \
+        && umount /mnt
+      )
+      mkdir -p ${mountpoint}
+      mount -t ${filesystem} ${device} ${mountpoint}
+      echo "${device} mounted at ${mountpoint}"
+      break
+    fi
+  done
+done

--- a/storage_worker.tf
+++ b/storage_worker.tf
@@ -1,0 +1,68 @@
+variable "storage_partlabel" {
+  default = "STORAGE"
+}
+
+data "ignition_disk" "storage_worker_sda" {
+  device     = "/dev/sda"
+  wipe_table = true
+
+  partition {
+    sizemib = 150000 // Approx 150 gigs
+    label   = var.storage_partlabel
+    number  = 1
+  }
+
+  partition {
+    label  = "ROOT"
+    number = 2
+  }
+}
+
+data "ignition_disk" "storage_worker_nvme" {
+  device     = "/dev/nvme0n1"
+  wipe_table = true
+
+  partition {
+    sizemib = 150000 // Approx 150 gigs
+    label   = var.storage_partlabel
+    number  = 1
+  }
+
+  partition {
+    label  = "ROOT"
+    number = 2
+  }
+}
+
+data "ignition_filesystem" "storage" {
+  device          = "/dev/disk/by-partlabel/${var.storage_partlabel}"
+  format          = "ext4"
+}
+
+data "ignition_file" "format_and_mount" {
+  mode = 493
+  path = "/opt/bin/format-and-mount"
+
+  content {
+    content = file("${path.module}/resources/format-and-mount")
+  }
+}
+
+data "template_file" "storage_disk_mounter" {
+  template = file("${path.module}/resources/disk-mounter.service")
+
+  vars = {
+    script_path = "/opt/bin/format-and-mount"
+    volume_id   = "disk/by-partlabel/${var.storage_partlabel}"
+    filesystem  = "ext4"
+    user        = "root"
+    group       = "root"
+    mountpoint  = var.worker_persistent_storage_mountpoint
+  }
+}
+
+data "ignition_systemd_unit" "storage_disk_mounter" {
+  name    = "disk-mounter.service"
+  content = data.template_file.storage_disk_mounter.rendered
+}
+

--- a/variables.tf
+++ b/variables.tf
@@ -156,6 +156,18 @@ variable "worker_ignition_directories" {
   description = "The ignition directories to provide to worker nodes."
 }
 
+variable "worker_persistent_storage_patition" {
+  description = "Whether to create a local disk partition for persistent storage on worker nodes"
+  type        = bool
+  default     = false
+}
+
+variable "worker_persistent_storage_mountpoint" {
+  description = "Location for the local storage partition to be mounted"
+  type        = string
+  default     = "/var/lib/csi-local-hostpath"
+}
+
 variable "nodes_subnet_cidr" {
   description = "Address range for kube slave nodes"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -171,3 +171,9 @@ variable "cluster_internal_svc_subnet" {
 variable "pod_network" {
   description = "pod network cidr"
 }
+
+variable "cfssl_local_patition_disk" {
+  description = "Whether to create a local disk partition for storing cfssl data"
+  type        = bool
+  default     = false
+}

--- a/worker.tf
+++ b/worker.tf
@@ -83,15 +83,15 @@ EOS
 }
 
 locals {
-  nvme_disk = var.worker_persistent_storage_patition ? data.ignition_disk.storage_worker_nvme.rendered : data.ignition_disk.devnvme.rendered
-  sata_disk = var.worker_persistent_storage_patition ? data.ignition_disk.storage_worker_sda.rendered : data.ignition_disk.devsda.rendered
+  worker_nvme_disk = var.worker_persistent_storage_patition ? data.ignition_disk.storage_worker_nvme.rendered : data.ignition_disk.devnvme.rendered
+  worker_sata_disk = var.worker_persistent_storage_patition ? data.ignition_disk.storage_worker_sda.rendered : data.ignition_disk.devsda.rendered
 }
 
 data "ignition_config" "worker" {
   count = length(var.worker_instances)
 
   disks = [
-    var.worker_instances[count.index].disk_type == "nvme" ? local.nvme_disk : local.sata_disk,
+    var.worker_instances[count.index].disk_type == "nvme" ? local.worker_nvme_disk : local.worker_sata_disk,
   ]
 
   filesystems = [

--- a/worker.tf
+++ b/worker.tf
@@ -82,19 +82,28 @@ EOS
   }
 }
 
+locals {
+  nvme_disk = var.worker_persistent_storage_patition ? data.ignition_disk.storage_worker_nvme.rendered : data.ignition_disk.devnvme.rendered
+  sata_disk = var.worker_persistent_storage_patition ? data.ignition_disk.storage_worker_sda.rendered : data.ignition_disk.devsda.rendered
+}
+
 data "ignition_config" "worker" {
   count = length(var.worker_instances)
 
   disks = [
-    var.worker_instances[count.index].disk_type == "nvme" ? data.ignition_disk.devnvme.rendered : data.ignition_disk.devsda.rendered,
+    var.worker_instances[count.index].disk_type == "nvme" ? local.nvme_disk : local.sata_disk,
   ]
 
   filesystems = [
     data.ignition_filesystem.root.rendered,
+    var.worker_persistent_storage_patition ? data.ignition_filesystem.storage.rendered : "",
   ]
 
   systemd = concat(
     var.worker_ignition_systemd,
+    [
+      var.worker_persistent_storage_patition ? data.ignition_systemd_unit.storage_disk_mounter.rendered : "",
+    ]
   )
 
   files = concat(
@@ -104,6 +113,7 @@ data "ignition_config" "worker" {
       data.ignition_file.bond_netdev.rendered,
       data.ignition_file.bond0_worker[count.index].rendered,
       data.ignition_file.worker_hostname[count.index].rendered,
+      var.worker_persistent_storage_patition ? data.ignition_file.format_and_mount.rendered : "",
     ]
   )
 


### PR DESCRIPTION
- Support disk partitioning on cfssl instances to persist data during boots (optional)
- Support disk partitioning on worker nodes for persistent storage (optional)
- No op on existing setups if flags are not enabled